### PR TITLE
Add Duration & related properties

### DIFF
--- a/duration.php
+++ b/duration.php
@@ -1,0 +1,55 @@
+<?php
+namespace shgysk8zer0\PHPSchema;
+
+use \shgysk8zer0\PHPSchema\Interfaces\{DurationInterface};
+use \DateTimeInterface;
+use \DateInterval;
+
+class Duration extends Quantity implements DurationInterface
+{
+	// @see https://schema.org/Duration
+
+	public const TYPE = 'Duration';
+
+	public const ISO8601DURATION = 'P%yY%mM%dDT%hH%iM%sS';
+
+	public function getDateInterval():? DateInterval
+	{
+		$ident = $this->getIdentifier();
+
+		if (isset($ident)) {
+			return new DateInterval($ident);
+		} else {
+			return null;
+		}
+	}
+
+	public function getDateIntervalAsString():? string
+	{
+		if ($interval = $this->getDateInterval()) {
+			return rtrim(str_replace(
+				['S0F', 'M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'],
+				['S', 'M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'],
+				$interval->format(self::ISO8601DURATION)
+			));
+		}
+	}
+
+	public function setDateInterval(?DateInterval $val): void
+	{
+		if (isset($val)) {
+			$this->setIdentifier(rtrim(str_replace(
+				['S0F', 'M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'],
+				['S', 'M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'],
+				$val->format(self::ISO8601DURATION)
+			)));
+		}
+	}
+
+	public static function fromDateTimes(DateTimeInterface $start, DateTimeInterface $end): DurationInterface
+	{
+		$dur = new self();
+		$dur->setDateInterval($start->diff($end));
+		return $dur;
+	}
+}

--- a/duration.php
+++ b/duration.php
@@ -5,51 +5,81 @@ use \shgysk8zer0\PHPSchema\Interfaces\{DurationInterface};
 use \DateTimeInterface;
 use \DateInterval;
 
+/**
+ * @see https://schema.org/Duration
+ *
+ * Note: This class must call `getDateIntervalAsString` when jsonifying.
+ * For compatibility reasons with parent classes, `jsonSerialize` cannot be
+ * made to return the formatted string, so its `jsonSerialize` returns an array
+ * containing the return of `getDateIntervalAsString`.
+ */
 class Duration extends Quantity implements DurationInterface
 {
-	// @see https://schema.org/Duration
-
 	public const TYPE = 'Duration';
 
 	public const ISO8601DURATION = 'P%yY%mM%dDT%hH%iM%sS';
 
+	public function jsonSerialize(): array
+	{
+		return [$this->getDateIntervalAsString()];
+	}
+
 	public function getDateInterval():? DateInterval
 	{
-		$ident = $this->getIdentifier();
-
-		if (isset($ident)) {
+		if ($ident = $this->getIdentifier()) {
 			return new DateInterval($ident);
 		} else {
 			return null;
 		}
 	}
 
-	public function getDateIntervalAsString():? string
+	final public function getDateIntervalAsString():? string
 	{
-		if ($interval = $this->getDateInterval()) {
-			return rtrim(str_replace(
-				['S0F', 'M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'],
-				['S', 'M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'],
-				$interval->format(self::ISO8601DURATION)
-			));
-		}
+		return $this->_getFormatttedInterval($this->getDateInterval());
 	}
 
 	public function setDateInterval(?DateInterval $val): void
 	{
-		if (isset($val)) {
-			$this->setIdentifier(rtrim(str_replace(
-				['S0F', 'M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'],
-				['S', 'M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'],
-				$val->format(self::ISO8601DURATION)
-			)));
+		$this->setIdentifier($this->_getFormatttedInterval($val));
+	}
+
+	final public function setDateRange(DateTimeInterface $start, DateTimeInterface $end): void
+	{
+		$this->setDateInterval($start->diff($end));
+	}
+
+	public static function fromDateRange(?DateTimeInterface $start, ?DateTimeInterface $end):? DurationInterface
+	{
+		if (isset($start, $end)) {
+			$dur = new self();
+			$dur->setDateRange($start, $end);
+			return $dur;
+		} else {
+			return null;
 		}
 	}
 
-	public static function fromDateTimes(DateTimeInterface $start, DateTimeInterface $end): DurationInterface
+	public function fromDateInterval(?DateInterval $val):? DurationInterface
 	{
-		$dur = new self();
-		$dur->setDateInterval($start->diff($end));
-		return $dur;
+		if (isset($val)) {
+			$dur = new self();
+			$dur->setDateInterval($val);
+			return $dur;
+		} else {
+			return null;
+		}
+	}
+
+	final protected function _getFormatttedInterval(?DateInterval $val):? string
+	{
+		if (isset($val)) {
+			return rtrim(str_replace(
+				['S0F', 'M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'],
+				['S', 'M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'],
+				$val->format(self::ISO8601DURATION)
+			));
+		} else {
+			return null;
+		}
 	}
 }

--- a/event.php
+++ b/event.php
@@ -2,13 +2,14 @@
 namespace shgysk8zer0\PHPSchema;
 
 use \shgysk8zer0\PHPSchema\Interfaces\{
+	DurationInterface,
+	EventAttendanceModeInterface,
 	EventInterface,
 	EventStatusTypeInterface,
 	PersonOrOrganizationInterface,
-	ThingInterface,
-	PlaceInterface,
 	OfferInterface,
-	EventAttendanceModeInterface,
+	PlaceInterface,
+	ThingInterface,
 };
 
 use \shgysk8zer0\PHPSchema\Traits\{
@@ -18,6 +19,7 @@ use \shgysk8zer0\PHPSchema\Traits\{
 	Durationtrait,
 };
 
+use \DateInterval;
 use \DateTimeInterface;
 
 class Event extends Thing implements EventInterface
@@ -32,6 +34,8 @@ class Event extends Thing implements EventInterface
 	private $_about = null;
 
 	private $_doorTime = null;
+
+	private $_duration = null;
 
 	private $_endDate = null;
 
@@ -94,9 +98,49 @@ class Event extends Thing implements EventInterface
 		$this->_doorTime = $val;
 	}
 
+	final public function getDuration():? DurationInterface
+	{
+		if (isset($this->_duration)) {
+			return $this->_duration;
+		} else {
+			return Duration::fromDaterange($this->getStartDate(), $this->getEndDate());
+		}
+	}
+
 	public function getDurationAsString():? string
 	{
-		return $this->calculateDurationAsString($this->getStartDate(), $this->getEndDate());
+		if ($dur = $this->getDuration()) {
+			return $dur->getDateIntervalAsString();
+		} else {
+			return null;
+		}
+	}
+
+	final public function getDurationAsDateInterval():? DateInterval
+	{
+		if ($dur = $this->getDuration()) {
+			return $dur->getDateInterval();
+		} else {
+			return null;
+		}
+	}
+
+	final public function setDuration(?DurationInterface $val): void
+	{
+		$this->_duration = $val;
+	}
+
+	final public function setDurationFromDateInterval(?DateInterval $val): void
+	{
+		$this->setDuration($this->getDurationFromDateInterval($val));
+	}
+
+	final public function setDurationFromDateRange(
+		?DateTimeInterface $from,
+		?DateTimeInterface $to
+	): void
+	{
+		$this->setDuration($this->getDurationFromDateRange($from, $to));
 	}
 
 	public function getEndDate():? DateTimeInterface

--- a/event.php
+++ b/event.php
@@ -11,7 +11,12 @@ use \shgysk8zer0\PHPSchema\Interfaces\{
 	EventAttendanceModeInterface,
 };
 
-use \shgysk8zer0\PHPSchema\Traits\{OffersTrait, LocationTrait, DateTimeTrait};
+use \shgysk8zer0\PHPSchema\Traits\{
+	OffersTrait,
+	LocationTrait,
+	DateTimeTrait,
+	Durationtrait,
+};
 
 use \DateTimeInterface;
 
@@ -20,6 +25,7 @@ class Event extends Thing implements EventInterface
 	use DateTimeTrait;
 	use LocationTrait;
 	use OffersTrait;
+	use DurationTrait;
 
 	public const TYPE = 'Event';
 
@@ -49,6 +55,7 @@ class Event extends Thing implements EventInterface
 			[
 				'about'               => $this->getAbout(),
 				'doorTime'            => $this->getDoorTimeAsString(),
+				'duration'            => $this->getDurationAsString(),
 				'endDate'             => $this->getEndDateAsString(),
 				'eventAttendanceMode' => $this->getEventAttendanceMode(),
 				'eventStatus'         => $this->getEventStatus(),
@@ -85,6 +92,11 @@ class Event extends Thing implements EventInterface
 	public function setDoorTime(?DateTimeInterface $val): void
 	{
 		$this->_doorTime = $val;
+	}
+
+	public function getDurationAsString():? string
+	{
+		return $this->calculateDurationAsString($this->getStartDate(), $this->getEndDate());
 	}
 
 	public function getEndDate():? DateTimeInterface

--- a/interfaces/durationinterface.php
+++ b/interfaces/durationinterface.php
@@ -14,5 +14,5 @@ interface DurationInterface extends QuantityInterface
 
 	public function setDateInterval(?DateInterval $val): void;
 
-	public static function fromDateTimes(DateTimeInterface $start, DateTimeInterface $end): DurationInterface;
+	public function setDateRange(DateTimeInterface $start, DateTimeInterface $end): void;
 }

--- a/interfaces/durationinterface.php
+++ b/interfaces/durationinterface.php
@@ -1,0 +1,18 @@
+<?php
+namespace shgysk8zer0\PHPSchema\Interfaces;
+
+use \DateTimeInterface;
+use \DateInterval;
+
+interface DurationInterface extends QuantityInterface
+{
+	// @see https://schema.org/Duration
+
+	public function getDateInterval():? DateInterval;
+
+	public function getDateIntervalAsString():? string;
+
+	public function setDateInterval(?DateInterval $val): void;
+
+	public static function fromDateTimes(DateTimeInterface $start, DateTimeInterface $end): DurationInterface;
+}

--- a/interfaces/eventinterface.php
+++ b/interfaces/eventinterface.php
@@ -14,6 +14,8 @@ interface EventInterface extends ThingInterface
 
 	public function setDoorTime(?DateTimeInterface $val): void;
 
+	public function getDurationAsString():? string;
+
 	public function getEndDate():? DateTimeInterface;
 
 	public function getEndDateAsString():? string;

--- a/interfaces/eventinterface.php
+++ b/interfaces/eventinterface.php
@@ -1,5 +1,7 @@
 <?php
 namespace shgysk8zer0\PHPSchema\Interfaces;
+
+use \DateInterval;
 use \DateTimeInterface;
 
 interface EventInterface extends ThingInterface
@@ -14,7 +16,13 @@ interface EventInterface extends ThingInterface
 
 	public function setDoorTime(?DateTimeInterface $val): void;
 
+	public function getDuration():? DurationInterface;
+
 	public function getDurationAsString():? string;
+
+	public function getDurationAsDateInterval():? DateInterval;
+
+	public function setDuration(?DurationInterface $val): void;
 
 	public function getEndDate():? DateTimeInterface;
 

--- a/traits/durationtrait.php
+++ b/traits/durationtrait.php
@@ -1,0 +1,34 @@
+<?php
+namespace shgysk8zer0\PHPSchema\Traits;
+
+use \DateTimeInterface;
+use \DateInterval;
+
+trait DurationTrait
+{
+	final public function calculateDuration(?DateTimeInterface $from, DateTimeInterface $to):? DateInterval
+	{
+		if (isset($from, $to)) {
+			return $from->diff($to);
+		} else {
+			return null;
+		}
+	}
+
+	final public function calculateDurationAsString(
+		?DateTimeInterface $from,
+		?DateTimeInterface $to,
+		string             $format = 'P%yY%mM%dDT%hH%iM%sS'
+		):? string
+	{
+		if ($diff = $this->calculateDuration($from, $to)) {
+			return rtrim(str_replace(
+				['S0F', 'M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'],
+				['S', 'M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'],
+				$diff->format($format)
+			));
+		} else {
+			return null;
+		}
+	}
+}

--- a/traits/durationtrait.php
+++ b/traits/durationtrait.php
@@ -1,32 +1,48 @@
 <?php
 namespace shgysk8zer0\PHPSchema\Traits;
 
+use \shgysk8zer0\PHPSchema\{Duration};
+use \shgysk8zer0\PHPSchema\Interfaces\{DurationInterface};
 use \DateTimeInterface;
 use \DateInterval;
 
 trait DurationTrait
 {
-	final public function calculateDuration(?DateTimeInterface $from, DateTimeInterface $to):? DateInterval
+	final public function getDurationFromDateRange(
+		?DateTimeInterface $from = null,
+		?DateTimeInterface $to   = null
+	):? DurationInterface
 	{
-		if (isset($from, $to)) {
-			return $from->diff($to);
+		return $this->getDurationFromDateInterval($from->diff($to));
+	}
+
+	final public function getDurationStringFromDateRange(
+		?DateTimeInterface $from = null,
+		?DateTimeInterface $to   = null
+	):? string
+	{
+		if ($dur = $this->getDurationFromDateRange($from, $to)) {
+			return $dur->getDateIntervalAsString();
 		} else {
 			return null;
 		}
 	}
 
-	final public function calculateDurationAsString(
-		?DateTimeInterface $from,
-		?DateTimeInterface $to,
-		string             $format = 'P%yY%mM%dDT%hH%iM%sS'
-		):? string
+	final public function getDurationFromDateInterval(?DateInterval $val): DurationInterface
 	{
-		if ($diff = $this->calculateDuration($from, $to)) {
-			return rtrim(str_replace(
-				['S0F', 'M0S', 'H0M', 'DT0H', 'M0D', 'Y0M', 'P0Y', 'Y0M', 'P0M'],
-				['S', 'M', 'H', 'DT', 'M', 'Y0M', 'P', 'Y', 'P'],
-				$diff->format($format)
-			));
+		if (isset($val)) {
+			$dur = new Duration();
+			$dur->setDateInterval($val);
+			return $dur;
+		} else {
+			return null;
+		}
+	}
+
+	final public function getDurationStringFromDateInterval(?DateInterval $diff):? string
+	{
+		if ($dur = $this->getDurationFromDateInterval($diff)) {
+			return $dur->getDateIntervalAsString();
 		} else {
 			return null;
 		}


### PR DESCRIPTION
Since there are no examples of Duration being used other than as a string, I'm not sure how to convert this to JSON. It extends Quantity, which itself extends Thing, but nothing adds any new properties, & I am unsure what to set using the encoded duration (P1DT2H30M).

Basically, despite extending Quantity, Duration seems to always be given exclusively as a string.